### PR TITLE
Fix Karras scheduler doesn't start from the actual max to min

### DIFF
--- a/modules/sd_samplers.py
+++ b/modules/sd_samplers.py
@@ -419,7 +419,7 @@ class KDiffusionSampler:
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif self.config is not None and self.config.options.get('scheduler', None) == 'karras':
-            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.1, sigma_max=10, device=shared.device)
+            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.03, sigma_max=14.5, device=shared.device)
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 
@@ -457,7 +457,7 @@ class KDiffusionSampler:
         if p.sampler_noise_scheduler_override:
             sigmas = p.sampler_noise_scheduler_override(steps)
         elif self.config is not None and self.config.options.get('scheduler', None) == 'karras':
-            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.1, sigma_max=10, device=shared.device)
+            sigmas = k_diffusion.sampling.get_sigmas_karras(n=steps, sigma_min=0.03, sigma_max=14.5, device=shared.device)
         else:
             sigmas = self.model_wrap.get_sigmas(steps)
 


### PR DESCRIPTION
Merging karras fix, original PR message was:

"I am looking into various of the new samplers and try it in my https://github.com/liuliu/swift-diffusion

There is this magical sigma_min / sigma_max for Karras scheduler seems a bit abrupt. Looking deeper into it, I believe that it is best to match the actual sigma max / sigma min used when training the model. That means for Stable Diffusion, it is the sigma at step 999 and at step 1.

I switched to that value, and both DPM++ 2S Karras and DPM++ 2M Karras looks much more consistent between step 10, step 20, step 30 and step
40. I believe this is a good improvement and don't want to keep it secret only in my repo.

I renounce all the copyright of this PR. Just merge it and fix it for everyone if people verified this is indeed a good fix."